### PR TITLE
Update variables.tf to fit the description 

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "cognitive_deployments" {
     model = object({
       format  = string
       name    = string
-      version = string
+      version = optional(string)
     })
     scale = object({
       capacity = optional(number)


### PR DESCRIPTION
the version-variable should be set to optional according the docs and the terraform-resource configuration

## Description
According to the official documentation ([link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_deployment#version)), the version parameter should be optional.
The documentation of this module already has the right description of the field.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
