### PR TITLE
Allow to pass dynamic throttling settings per deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ Type:
 
 ```hcl
 map(object({
-    name                   = string
-    rai_policy_name        = optional(string)
-    version_upgrade_option = optional(string)
+    name                       = string
+    rai_policy_name            = optional(string)
+    version_upgrade_option     = optional(string)
+    dynamic_throttling_enabled = optional(bool)
     model = object({
       format  = string
       name    = string

--- a/examples/Azure-AI-Service/README.md
+++ b/examples/Azure-AI-Service/README.md
@@ -186,29 +186,29 @@ resource "random_uuid" "role_assignments_names" {
 
 # this gives your service principal the HSM Crypto User role which lets you create and destroy hsm keys
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "hsm_crypto_user" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
   name               = random_uuid.role_assignments_names[0].result
   principal_id       = data.azurerm_client_config.this.object_id
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
   scope              = "/keys"
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
 }
 
 # this gives your service principal the HSM Crypto Officer role which lets you purge hsm keys
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "hsm_crypto_officer" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
   name               = random_uuid.role_assignments_names[1].result
   principal_id       = data.azurerm_client_config.this.object_id
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"
   scope              = "/keys"
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
 }
 
 # this gives your service principal the HSM Crypto User role to UAI for wrap/unwrap operations
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "uai_crypto_user" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
   name               = random_uuid.role_assignments_names[2].result
   principal_id       = azurerm_user_assigned_identity.this.principal_id
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
   scope              = "/keys"
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
 }
 
 resource "time_sleep" "role_assignment" {

--- a/examples/Azure-AI-Service/main.tf
+++ b/examples/Azure-AI-Service/main.tf
@@ -180,29 +180,29 @@ resource "random_uuid" "role_assignments_names" {
 
 # this gives your service principal the HSM Crypto User role which lets you create and destroy hsm keys
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "hsm_crypto_user" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
   name               = random_uuid.role_assignments_names[0].result
   principal_id       = data.azurerm_client_config.this.object_id
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
   scope              = "/keys"
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
 }
 
 # this gives your service principal the HSM Crypto Officer role which lets you purge hsm keys
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "hsm_crypto_officer" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
   name               = random_uuid.role_assignments_names[1].result
   principal_id       = data.azurerm_client_config.this.object_id
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"
   scope              = "/keys"
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
 }
 
 # this gives your service principal the HSM Crypto User role to UAI for wrap/unwrap operations
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "uai_crypto_user" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
   name               = random_uuid.role_assignments_names[2].result
   principal_id       = azurerm_user_assigned_identity.this.principal_id
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
   scope              = "/keys"
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.this.id
 }
 
 resource "time_sleep" "role_assignment" {

--- a/main.tf
+++ b/main.tf
@@ -144,10 +144,11 @@ resource "azurerm_cognitive_account_customer_managed_key" "this" {
 resource "azurerm_cognitive_deployment" "this" {
   for_each = var.cognitive_deployments
 
-  cognitive_account_id   = local.resource_block.id
-  name                   = each.value.name
-  rai_policy_name        = each.value.rai_policy_name
-  version_upgrade_option = each.value.version_upgrade_option
+  cognitive_account_id       = local.resource_block.id
+  name                       = each.value.name
+  dynamic_throttling_enabled = each.value.dynamic_throttling_enabled
+  rai_policy_name            = each.value.rai_policy_name
+  version_upgrade_option     = each.value.version_upgrade_option
 
   dynamic "model" {
     for_each = [each.value.model]
@@ -163,9 +164,9 @@ resource "azurerm_cognitive_deployment" "this" {
     iterator = scale
 
     content {
+      name     = scale.value.type
       capacity = scale.value.capacity
       family   = scale.value.family
-      name     = scale.value.type
       size     = scale.value.size
       tier     = scale.value.tier
     }

--- a/variables.tf
+++ b/variables.tf
@@ -30,9 +30,10 @@ variable "sku_name" {
 
 variable "cognitive_deployments" {
   type = map(object({
-    name                   = string
-    rai_policy_name        = optional(string)
-    version_upgrade_option = optional(string)
+    name                       = string
+    rai_policy_name            = optional(string)
+    version_upgrade_option     = optional(string)
+    dynamic_throttling_enabled = optional(bool)
     model = object({
       format  = string
       name    = string


### PR DESCRIPTION
## Description

Current dynamic throttling support is limited to service accounts. This update adds an optional field to `azurerm_cognitive_deployment`, allowing dynamic throttling settings to be configured per deployment, similar to existing configurations.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
