### PR TITLE
fix: Update Azure-OpenAI-with-customer_managed_key_encryption example to use OpenAI kind

### DIFF
--- a/examples/Azure-OpenAI-with-customer_managed_key_encryption/README.md
+++ b/examples/Azure-OpenAI-with-customer_managed_key_encryption/README.md
@@ -133,11 +133,11 @@ resource "azurerm_key_vault_key" "key" {
 module "test" {
   source = "../../"
 
-  kind      = "Face"
+  kind      = "OpenAI"
   location  = azurerm_resource_group.this.location
-  name      = "Face-${module.naming.cognitive_account.name_unique}"
+  name      = "OpenAI-${module.naming.cognitive_account.name_unique}"
   parent_id = azurerm_resource_group.this.id
-  sku_name  = "E0"
+  sku_name  = "S0"
   customer_managed_key = {
     key_vault_resource_id = azurerm_key_vault.this.id
     key_name              = azurerm_key_vault_key.key.name

--- a/examples/Azure-OpenAI-with-customer_managed_key_encryption/main.tf
+++ b/examples/Azure-OpenAI-with-customer_managed_key_encryption/main.tf
@@ -126,11 +126,11 @@ resource "azurerm_key_vault_key" "key" {
 module "test" {
   source = "../../"
 
-  kind      = "Face"
+  kind      = "OpenAI"
   location  = azurerm_resource_group.this.location
-  name      = "Face-${module.naming.cognitive_account.name_unique}"
+  name      = "OpenAI-${module.naming.cognitive_account.name_unique}"
   parent_id = azurerm_resource_group.this.id
-  sku_name  = "E0"
+  sku_name  = "S0"
   customer_managed_key = {
     key_vault_resource_id = azurerm_key_vault.this.id
     key_name              = azurerm_key_vault_key.key.name


### PR DESCRIPTION
## Description

This PR fixes the `Azure-OpenAI-with-customer_managed_key_encryption` example to correctly create an OpenAI resource instead of a Face API resource.

## Changes

- Updated `kind` from `"Face"` to `"OpenAI"` in the example module configuration
- Updated resource name from `"Face-${...}"` to `"OpenAI-${...}"` to match the resource type

## Related Issue

Fixes #157

## Testing

- [ ] Code has been reviewed and updated
- [ ] Example aligns with its intended purpose (OpenAI with customer managed key encryption)

---

Thank you @chopeen for reporting this issue!