### PR TITLE
Fix: Handle null value for local_auth_enabled to retrieve account keys

### DIFF
--- a/main.aiservies.tf
+++ b/main.aiservies.tf
@@ -151,7 +151,7 @@ resource "azapi_update_resource" "ai_service_hsm_key" {
 }
 
 data "azapi_resource_action" "ai_service_account_keys" {
-  count = var.kind == "AIServices" && try(var.local_auth_enabled, true) ? 1 : 0
+  count = var.kind == "AIServices" && coalesce(var.local_auth_enabled, true) ? 1 : 0
 
   action                           = "listKeys"
   resource_id                      = azapi_resource.ai_service[0].id

--- a/main.tf
+++ b/main.tf
@@ -149,7 +149,7 @@ resource "time_sleep" "wait_account_creation" {
 }
 
 data "azapi_resource_action" "account_keys" {
-  count = var.kind != "AIServices" && try(var.local_auth_enabled, true) ? 1 : 0
+  count = var.kind != "AIServices" && coalesce(var.local_auth_enabled, true) ? 1 : 0
 
   action                           = "listKeys"
   resource_id                      = azapi_resource.this[0].id


### PR DESCRIPTION
## Description

This PR fixes a bug where setting `var.local_auth_enabled` to its default value of `null` prevents the module from retrieving account keys, even though local authentication is actually enabled on the Azure resource.

## Issue Reference

Fixes #152

## Root Cause

When `var.local_auth_enabled` is `null`, the expression `try(var.local_auth_enabled, true)` in the data source count condition returns `null` instead of `true`. In Terraform's boolean context, `null` evaluates to `false`, causing `count = 0` and preventing the key retrieval data sources from executing.

This resulted in:
- `primary_access_key` being `null`
- `secondary_access_key` being `null`
- Breaking backward compatibility

## Changes

Replaced `try(var.local_auth_enabled, true)` with `coalesce(var.local_auth_enabled, true)` in both:
- `main.tf` line 152 (for non-AIServices kinds)
- `main.aiservies.tf` line 154 (for AIServices kind)

## Why coalesce()?

The `coalesce()` function properly handles `null` values by returning the first non-null argument, ensuring that when `var.local_auth_enabled` is `null`, it correctly defaults to `true`, maintaining the documented behavior and backward compatibility.

## Testing

This change ensures that:
- When `local_auth_enabled` is `null` (default), keys are retrieved ✅
- When `local_auth_enabled = true`, keys are retrieved ✅
- When `local_auth_enabled = false`, keys are NOT retrieved ✅

---

Thanks to @chopeen for the detailed bug report and patience in following up on this issue.