### PR TITLE
fix: remove network_acls.bypass kind restriction

### DIFF
--- a/main.aiservies.tf
+++ b/main.aiservies.tf
@@ -50,6 +50,7 @@ resource "azapi_resource" "ai_service" {
             id                               = rule.subnet_id
             ignoreMissingVnetServiceEndpoint = rule.ignore_missing_vnet_service_endpoint == true
           }], null)
+          bypass = var.network_acls.bypass
         }, null) : k => v if v != null }, null)
         userOwnedStorage = try([for storage in var.storage : {
           resourceId       = storage.storage_account_id
@@ -80,11 +81,6 @@ resource "azapi_resource" "ai_service" {
       body.properties.apiProperties.qnaAzureSearchEndpointKey,
       body.properties.encryption
     ]
-
-    precondition {
-      condition     = var.network_acls == null ? true : (var.network_acls.bypass == null || var.network_acls.bypass == "")
-      error_message = "the `network_acls.bypass` does not support Trusted Services for the kind `${var.kind}`"
-    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "azapi_resource" "this" {
           id                               = rule.subnet_id
           ignoreMissingVnetServiceEndpoint = rule.ignore_missing_vnet_service_endpoint == true
         }], null)
-        bypass = var.kind == "OpenAI" ? var.network_acls.bypass : null
+        bypass = var.network_acls.bypass
       }, null) : k => v if v != null }, null)
       userOwnedStorage = try([for storage in var.storage : {
         resourceId       = storage.storage_account_id
@@ -130,10 +130,6 @@ resource "azapi_resource" "this" {
     precondition {
       condition     = var.metrics_advisor_website_name == null || var.kind == "MetricsAdvisor"
       error_message = "metrics_advisor_website_name can only used set when kind is set to `MetricsAdvisor`"
-    }
-    precondition {
-      condition     = var.network_acls == null ? true : (var.network_acls.bypass == null || var.network_acls.bypass == "" || var.kind == "OpenAI")
-      error_message = "the `network_acls.bypass` does not support Trusted Services for the kind `${var.kind}`"
     }
   }
 }


### PR DESCRIPTION
Remove the precondition that limited network_acls.bypass to only OpenAI kind. This allows other Cognitive Services kinds like TextAnalytics to also use the network_acls.bypass setting.

Also added bypass support for AIServices kind in main.aiservies.tf.

Fixes #154

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
