### PR TITLE
feat: support modelProviderData for cognitive deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,17 @@ Description: - `name` - (Required) The name of the Cognitive Services Account De
 
 ---
 `model` block supports the following:
-- `format` - (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is `OpenAI`.
+- `format` - (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Common values are `OpenAI` and `Anthropic`.
 - `name` - (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
 - `version` - (Optional) The version of Cognitive Services Account Deployment model. If `version` is not specified, the default version of the model at the time will be assigned.
+
+---
+`model_provider_data` block supports the following:
+- `organization_name` - (Required) The name of the organization accepting the partner model's terms.
+- `country_code` - (Required) The country code of the organization, as expected by the Azure resource provider.
+- `industry` - (Required) The industry of the organization, as expected by the Azure resource provider.
+
+This block is required by the Azure resource provider for supported GA partner-model deployments (for example, Anthropic Claude models where `model.format` is `Anthropic`) and is omitted from the deployment request when not supplied. It is not required for first-party `OpenAI` deployments.
 
 ---
 `scale` block supports the following:
@@ -220,6 +228,11 @@ map(object({
       name    = string
       version = optional(string)
     })
+    model_provider_data = optional(object({
+      organization_name = string
+      country_code      = string
+      industry          = string
+    }), null)
     scale = object({
       capacity = optional(number, 1)
       family   = optional(string)

--- a/main.tf
+++ b/main.tf
@@ -246,6 +246,7 @@ module "deployment" {
   dynamic_throttling_enabled = each.value.dynamic_throttling_enabled
   enable_telemetry           = var.enable_telemetry
   lock_id                    = var.deployment_serialization_enabled ? local.resource_id : null
+  model_provider_data        = each.value.model_provider_data
   rai_policy_name            = each.value.rai_policy_name
   retry = each.value.retry != null ? {
     error_message_regex  = each.value.retry.error_message_regex

--- a/modules/deployment/README.md
+++ b/modules/deployment/README.md
@@ -39,7 +39,7 @@ The following input variables are required:
 
 ### <a name="input_model"></a> [model](#input\_model)
 
-Description: - `format`  - (Required) The format of the Cognitive Services Account Deployment model. Possible value is `OpenAI`.
+Description: - `format`  - (Required) The format of the Cognitive Services Account Deployment model. Common values are `OpenAI` and `Anthropic`.
 - `name`    - (Required) The name of the Cognitive Services Account Deployment model.
 - `version` - (Optional) The version of Cognitive Services Account Deployment model.
 
@@ -112,6 +112,26 @@ Default: `true`
 Description: (Optional) Resource ID used as a mutex to serialize deployment operations. When set, the parent Cognitive Services Account ID is typically used so AzAPI serializes create/update operations across sibling deployments.
 
 Type: `string`
+
+Default: `null`
+
+### <a name="input_model_provider_data"></a> [model\_provider\_data](#input\_model\_provider\_data)
+
+Description: (Optional) Model-provider attestation data required for supported partner-model deployments (for example, Anthropic Claude). Defaults to `null`, in which case `modelProviderData` is omitted from the deployment request. Not required for first-party `OpenAI` deployments.
+
+ - `organization_name` - (Required) The name of the organization accepting the partner model's terms.
+ - `country_code`      - (Required) The country code of the organization, as expected by the Azure resource provider.
+ - `industry`          - (Required) The industry of the organization, as expected by the Azure resource provider.
+
+Type:
+
+```hcl
+object({
+    organization_name = string
+    country_code      = string
+    industry          = string
+  })
+```
 
 Default: `null`
 

--- a/modules/deployment/main.tf
+++ b/modules/deployment/main.tf
@@ -1,7 +1,7 @@
 resource "azapi_resource" "this" {
   name      = var.name
   parent_id = var.parent_id
-  type      = "Microsoft.CognitiveServices/accounts/deployments@2025-06-01"
+  type      = "Microsoft.CognitiveServices/accounts/deployments@2026-05-01"
   body = {
     properties = { for k, v in {
       dynamicThrottlingEnabled = var.dynamic_throttling_enabled
@@ -9,6 +9,11 @@ resource "azapi_resource" "this" {
         format  = var.model.format
         name    = var.model.name
         version = var.model.version
+      }
+      modelProviderData = var.model_provider_data == null ? null : {
+        organizationName = var.model_provider_data.organization_name
+        countryCode      = var.model_provider_data.country_code
+        industry         = var.model_provider_data.industry
       }
       raiPolicyName        = var.rai_policy_name
       versionUpgradeOption = var.version_upgrade_option

--- a/modules/deployment/tests/unit/unit.tftest.hcl
+++ b/modules/deployment/tests/unit/unit.tftest.hcl
@@ -1,0 +1,88 @@
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  parent_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.CognitiveServices/accounts/aiservices-test"
+  enable_telemetry = false
+}
+
+# Partner-model deployment (e.g. Anthropic Claude) supplying model_provider_data.
+run "partner_model_deployment" {
+  command = apply
+
+  variables {
+    name = "claude-deployment"
+    model = {
+      format  = "Anthropic"
+      name    = "claude-opus-4-1"
+      version = "1"
+    }
+    scale = {
+      type     = "GlobalStandard"
+      capacity = 1
+    }
+    model_provider_data = {
+      organization_name = "Contoso"
+      country_code      = "US"
+      industry          = "Technology"
+    }
+  }
+
+  assert {
+    condition     = azapi_resource.this.type == "Microsoft.CognitiveServices/accounts/deployments@2026-05-01"
+    error_message = "The deployment resource must use the 2026-05-01 API version that supports modelProviderData."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.modelProviderData.organizationName == "Contoso"
+    error_message = "modelProviderData.organizationName should be mapped from model_provider_data.organization_name."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.modelProviderData.countryCode == "US"
+    error_message = "modelProviderData.countryCode should be mapped from model_provider_data.country_code."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.modelProviderData.industry == "Technology"
+    error_message = "modelProviderData.industry should be mapped from model_provider_data.industry."
+  }
+}
+
+# Backward-compatible OpenAI deployment that does not supply model_provider_data.
+run "openai_deployment_without_model_provider_data" {
+  command = apply
+
+  variables {
+    name = "gpt-deployment"
+    model = {
+      format  = "OpenAI"
+      name    = "gpt-4.1-mini"
+      version = "2025-04-14"
+    }
+    scale = {
+      type = "Standard"
+    }
+  }
+
+  assert {
+    condition     = !contains(keys(azapi_resource.this.body.properties), "modelProviderData")
+    error_message = "modelProviderData must be omitted from the request body when model_provider_data is not supplied."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.model.format == "OpenAI"
+    error_message = "Existing OpenAI deployment inputs must continue to work unchanged."
+  }
+
+  assert {
+    condition     = azapi_resource.this.body.properties.model.name == "gpt-4.1-mini"
+    error_message = "Existing OpenAI deployment inputs must continue to work unchanged."
+  }
+
+  assert {
+    condition     = azapi_resource.this.type == "Microsoft.CognitiveServices/accounts/deployments@2026-05-01"
+    error_message = "The deployment resource must use the 2026-05-01 API version regardless of model_provider_data."
+  }
+}

--- a/modules/deployment/variables.tf
+++ b/modules/deployment/variables.tf
@@ -5,7 +5,7 @@ variable "model" {
     version = optional(string)
   })
   description = <<-DESCRIPTION
- - `format`  - (Required) The format of the Cognitive Services Account Deployment model. Possible value is `OpenAI`.
+ - `format`  - (Required) The format of the Cognitive Services Account Deployment model. Common values are `OpenAI` and `Anthropic`.
  - `name`    - (Required) The name of the Cognitive Services Account Deployment model.
  - `version` - (Optional) The version of Cognitive Services Account Deployment model.
 DESCRIPTION
@@ -62,6 +62,22 @@ variable "lock_id" {
   type        = string
   default     = null
   description = "(Optional) Resource ID used as a mutex to serialize deployment operations. When set, the parent Cognitive Services Account ID is typically used so AzAPI serializes create/update operations across sibling deployments."
+}
+
+variable "model_provider_data" {
+  type = object({
+    organization_name = string
+    country_code      = string
+    industry          = string
+  })
+  default     = null
+  description = <<-DESCRIPTION
+(Optional) Model-provider attestation data required for supported partner-model deployments (for example, Anthropic Claude). Defaults to `null`, in which case `modelProviderData` is omitted from the deployment request. Not required for first-party `OpenAI` deployments.
+
+ - `organization_name` - (Required) The name of the organization accepting the partner model's terms.
+ - `country_code`      - (Required) The country code of the organization, as expected by the Azure resource provider.
+ - `industry`          - (Required) The industry of the organization, as expected by the Azure resource provider.
+DESCRIPTION
 }
 
 variable "rai_policy_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,11 @@ variable "cognitive_deployments" {
       name    = string
       version = optional(string)
     })
+    model_provider_data = optional(object({
+      organization_name = string
+      country_code      = string
+      industry          = string
+    }), null)
     scale = object({
       capacity = optional(number, 1)
       family   = optional(string)
@@ -101,9 +106,17 @@ variable "cognitive_deployments" {
 
  ---
  `model` block supports the following:
- - `format` - (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is `OpenAI`.
+ - `format` - (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Common values are `OpenAI` and `Anthropic`.
  - `name` - (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
  - `version` - (Optional) The version of Cognitive Services Account Deployment model. If `version` is not specified, the default version of the model at the time will be assigned.
+
+ ---
+ `model_provider_data` block supports the following:
+ - `organization_name` - (Required) The name of the organization accepting the partner model's terms.
+ - `country_code` - (Required) The country code of the organization, as expected by the Azure resource provider.
+ - `industry` - (Required) The industry of the organization, as expected by the Azure resource provider.
+
+ This block is required by the Azure resource provider for supported GA partner-model deployments (for example, Anthropic Claude models where `model.format` is `Anthropic`) and is omitted from the deployment request when not supplied. It is not required for first-party `OpenAI` deployments.
 
  ---
  `scale` block supports the following:


### PR DESCRIPTION
## Description

Adds optional `model_provider_data` support for Cognitive Services account deployments and maps it to the ARM `properties.modelProviderData` payload.

This enables the Terraform AVM module to represent the model-provider attestation required for supported GA partner models, including Anthropic Claude.

The change:

* Adds optional `model_provider_data` to each `cognitive_deployments` entry.
* Passes the value from the root module to `modules/deployment`.
* Maps Terraform-style field names to the required ARM property names:

  * `organization_name` → `organizationName`
  * `country_code` → `countryCode`
  * `industry` → `industry`
* Omits `modelProviderData` when the input is not supplied.
* Updates the deployment resource API version to `2026-05-01`.
* Preserves backward compatibility for existing OpenAI and other deployments.
* Adds deterministic unit tests for partner-model and backward-compatible deployment scenarios.
* Regenerates the affected module documentation.

## Context

The Cognitive Services resource provider requires `modelProviderData` when deploying certain partner models. The current Terraform AVM deployment submodule does not expose this property and uses an API version that does not support it.

The Terraform module already implements `Microsoft.CognitiveServices/accounts/deployments` through the dedicated `modules/deployment` submodule. Therefore, unlike the corresponding Bicep work, no additional child-resource extraction is required.

## References

Closes #204

* Terraform issue: [[Azure/terraform-azurerm-avm-res-cognitiveservices-account#204](https://github.com/Azure/terraform-azurerm-avm-res-cognitiveservices-account/issues/204)](https://github.com/Azure/terraform-azurerm-avm-res-cognitiveservices-account/issues/204)
* Related Bicep implementation: [[Azure/bicep-registry-modules#7199](https://github.com/Azure/bicep-registry-modules/pull/7199)](https://github.com/Azure/bicep-registry-modules/pull/7199)
* Related Bicep child-module issue: [[Azure/bicep-registry-modules#7206](https://github.com/Azure/bicep-registry-modules/issues/7206)](https://github.com/Azure/bicep-registry-modules/issues/7206)

## Type of Change

* [ ] Non-module change (e.g. CI/CD, documentation, etc.)
* [x] Azure Verified Module updates:

  * [ ] Bugfix containing backwards-compatible bug fixes

    * [ ] Someone has opened a bug report issue, and I have included `Closes #{bug_report_issue_number}` in the PR description.
    * [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  * [x] Feature update containing backward-compatible functionality.
  * [ ] Breaking changes.
  * [x] Update to documentation.

## Validation

> [!NOTE]
> Docker was not available in the local environment used to prepare this PR. Therefore, the repository’s containerized AVM wrapper commands could not be executed locally:
>
> ```bash
> PORCH_NO_TUI=1 ./avm tf-test-unit
> PORCH_NO_TUI=1 ./avm pre-commit
> PORCH_NO_TUI=1 ./avm pr-check
> ```
>
> These mandatory checks remain pending and must pass in CI before merge. They use the repository-pinned toolchain and complete AVM-specific validation that could not be fully reproduced locally.

The following substitute checks were executed successfully:

* `terraform test` for `modules/deployment/tests/unit` — **2 passed, 0 failed**.
* `terraform fmt -check -diff -recursive .` — clean, no differences.
* `terraform validate` — successful for both the root module and `modules/deployment`.
* `terraform-docs -c .terraform-docs.yml .` — regenerated the root and deployment-submodule documentation.
* `tflint --recursive` — no findings using the bundled ruleset.

Local tool versions:

* Terraform `v1.15.8`
* terraform-docs `v0.24.0`
* TFLint `v0.63.1`

The repository pins terraform-docs `~> 0.18`; consequently, CI may normalize generated documentation using the repository-pinned version.

Tests cover:

* A deployment with `model_provider_data` supplied.
* Exact mapping to `properties.modelProviderData`.
* A deployment without `model_provider_data`.
* Omission of `modelProviderData` when the input is `null`.
* Use of the `2026-05-01` deployment API version.

## Backward Compatibility

This is a backward-compatible feature update.

Existing configurations do not need to provide `model_provider_data`. When omitted, the generated deployment request retains the existing behavior and does not include `properties.modelProviderData`.

## Limitations and Open Items

* The `2026-05-01` API version is not yet represented fully in the current `bicep-types-az` schema catalog. Although the API version is available as a non-preview version, the deployment resource schema does not currently expose `modelProviderData`. This mirrors the equivalent Bicep implementation.
* The deployment resource already uses `schema_validation_enabled = false`, so the missing local schema representation does not block the request body from being submitted to Azure.
* No live Anthropic deployment example was added. The PR uses deterministic mocked unit tests to avoid CI dependencies on regional model availability, quota, and Marketplace acceptance. End-to-end coverage can be added if maintainers require it.

## Checklist

* [x] I'm sure there are no other open pull requests for the same change.
* [ ] My corresponding pipelines and checks run clean and green without errors or warnings.
  *Pending CI execution.*
* [ ] I ran all required [[pre-commit checks](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks)](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks).
  *The containerized `./avm pre-commit` command could not be run locally because Docker was unavailable. See the Validation section for the substitute checks that passed.*