### PR TITLE
fix: remove unresolvable moved blocks that recreate deployments and RAI policies on upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,80 @@ This Terraform module is designed to manage Azure Cognitive Services. It provide
 >
 > If you have `private_endpoints_manage_dns_zone_group = false`, no action is required.
 
+## Migration Guide for Cognitive Deployments and RAI Policies
+
+> [!WARNING]
+> **Breaking Change for `cognitive_deployments` and `rai_policies` Users (v0.11.1 → v0.12.0+)**
+>
+> v0.11.1 relocated model deployments and RAI policies from root-level resources into the
+> `modules/deployment` and `modules/rai_policy` submodules, and shipped `moved` blocks that
+> Terraform cannot resolve. A `moved` block cannot carry a resource's instance keys across
+> into module instance keys, so the move resolved to
+> `module.deployment.azapi_resource.this["<key>"]` — an address that does not exist — and
+> Terraform planned a **destroy and recreate of every deployment**. Destroying a live
+> `Microsoft.CognitiveServices/accounts/deployments` drops the model endpoint during apply.
+>
+> Those `moved` blocks have been removed. Because AVM
+> [TFRMNFR1](https://azure.github.io/Azure-Verified-Modules/spec/TFRMNFR1) requires
+> cardinality to stay on the submodule call, this migration cannot be shipped inside the
+> module — declare per-key `moved` blocks in your own configuration instead.
+>
+> **Who needs to act:** anyone with a non-empty `cognitive_deployments` or `rai_policies`
+> whose state still holds `azapi_resource.cognitive_deployment` / `azapi_resource.rai_policy`
+> (that is, anyone on v0.11.0 or earlier, and anyone on v0.11.1 who has not applied the
+> destructive plan). If you already applied v0.11.1 your state is at the new addresses and
+> **no action is required**.
+>
+> **Always run `terraform plan` and confirm it reports no changes before applying.**
+>
+> **Step 1 — generate the `moved` blocks from your current state:**
+>
+> ```bash
+> terraform state list \
+>   | grep -E '\.azapi_resource\.(cognitive_deployment|rai_policy)\[' \
+>   | while IFS= read -r addr; do
+>       prefix="${addr%%.azapi_resource.*}"
+>       rest="${addr#*.azapi_resource.}"
+>       rtype="${rest%%\[*}"
+>       key="${rest#*[\"}"; key="${key%\"]}"
+>       case "$rtype" in
+>         cognitive_deployment) sub="deployment" ;;
+>         rai_policy)           sub="rai_policy" ;;
+>       esac
+>       printf 'moved {\n  from = %s\n  to   = %s.module.%s["%s"].azapi_resource.this\n}\n\n' \
+>         "$addr" "$prefix" "$sub" "$key"
+>     done
+> ```
+>
+> **Step 2 — paste the output into your root configuration alongside the version bump:**
+>
+> ```hcl
+> moved {
+>   from = module.cognitive_service.azapi_resource.cognitive_deployment["gpt-4o"]
+>   to   = module.cognitive_service.module.deployment["gpt-4o"].azapi_resource.this
+> }
+>
+> moved {
+>   from = module.cognitive_service.azapi_resource.rai_policy["policy0"]
+>   to   = module.cognitive_service.module.rai_policy["policy0"].azapi_resource.this
+> }
+> ```
+>
+> **Step 3** — run `terraform plan`. It must report **no changes** for the deployment and
+> policy resources. If it still plans a destroy, a key is missing or misspelled; do not
+> apply. Once applied, the `moved` blocks can be deleted.
+>
+> **Upgrading from a pre-`azapi` version:** if your state still holds
+> `azurerm_cognitive_deployment.this["<key>"]`, move it straight to the new address in one
+> hop — the `azapi` provider supports the cross-type move:
+>
+> ```hcl
+> moved {
+>   from = module.cognitive_service.azurerm_cognitive_deployment.this["gpt-4o"]
+>   to   = module.cognitive_service.module.deployment["gpt-4o"].azapi_resource.this
+> }
+> ```
+
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 

--- a/_header.md
+++ b/_header.md
@@ -44,3 +44,77 @@ This Terraform module is designed to manage Azure Cognitive Services. It provide
 > ```
 >
 > If you have `private_endpoints_manage_dns_zone_group = false`, no action is required.
+
+## Migration Guide for Cognitive Deployments and RAI Policies
+
+> [!WARNING]
+> **Breaking Change for `cognitive_deployments` and `rai_policies` Users (v0.11.1 → v0.12.0+)**
+>
+> v0.11.1 relocated model deployments and RAI policies from root-level resources into the
+> `modules/deployment` and `modules/rai_policy` submodules, and shipped `moved` blocks that
+> Terraform cannot resolve. A `moved` block cannot carry a resource's instance keys across
+> into module instance keys, so the move resolved to
+> `module.deployment.azapi_resource.this["<key>"]` — an address that does not exist — and
+> Terraform planned a **destroy and recreate of every deployment**. Destroying a live
+> `Microsoft.CognitiveServices/accounts/deployments` drops the model endpoint during apply.
+>
+> Those `moved` blocks have been removed. Because AVM
+> [TFRMNFR1](https://azure.github.io/Azure-Verified-Modules/spec/TFRMNFR1) requires
+> cardinality to stay on the submodule call, this migration cannot be shipped inside the
+> module — declare per-key `moved` blocks in your own configuration instead.
+>
+> **Who needs to act:** anyone with a non-empty `cognitive_deployments` or `rai_policies`
+> whose state still holds `azapi_resource.cognitive_deployment` / `azapi_resource.rai_policy`
+> (that is, anyone on v0.11.0 or earlier, and anyone on v0.11.1 who has not applied the
+> destructive plan). If you already applied v0.11.1 your state is at the new addresses and
+> **no action is required**.
+>
+> **Always run `terraform plan` and confirm it reports no changes before applying.**
+>
+> **Step 1 — generate the `moved` blocks from your current state:**
+>
+> ```bash
+> terraform state list \
+>   | grep -E '\.azapi_resource\.(cognitive_deployment|rai_policy)\[' \
+>   | while IFS= read -r addr; do
+>       prefix="${addr%%.azapi_resource.*}"
+>       rest="${addr#*.azapi_resource.}"
+>       rtype="${rest%%\[*}"
+>       key="${rest#*[\"}"; key="${key%\"]}"
+>       case "$rtype" in
+>         cognitive_deployment) sub="deployment" ;;
+>         rai_policy)           sub="rai_policy" ;;
+>       esac
+>       printf 'moved {\n  from = %s\n  to   = %s.module.%s["%s"].azapi_resource.this\n}\n\n' \
+>         "$addr" "$prefix" "$sub" "$key"
+>     done
+> ```
+>
+> **Step 2 — paste the output into your root configuration alongside the version bump:**
+>
+> ```hcl
+> moved {
+>   from = module.cognitive_service.azapi_resource.cognitive_deployment["gpt-4o"]
+>   to   = module.cognitive_service.module.deployment["gpt-4o"].azapi_resource.this
+> }
+>
+> moved {
+>   from = module.cognitive_service.azapi_resource.rai_policy["policy0"]
+>   to   = module.cognitive_service.module.rai_policy["policy0"].azapi_resource.this
+> }
+> ```
+>
+> **Step 3** — run `terraform plan`. It must report **no changes** for the deployment and
+> policy resources. If it still plans a destroy, a key is missing or misspelled; do not
+> apply. Once applied, the `moved` blocks can be deleted.
+>
+> **Upgrading from a pre-`azapi` version:** if your state still holds
+> `azurerm_cognitive_deployment.this["<key>"]`, move it straight to the new address in one
+> hop — the `azapi` provider supports the cross-type move:
+>
+> ```hcl
+> moved {
+>   from = module.cognitive_service.azurerm_cognitive_deployment.this["gpt-4o"]
+>   to   = module.cognitive_service.module.deployment["gpt-4o"].azapi_resource.this
+> }
+> ```

--- a/main.rai_policy.tf
+++ b/main.rai_policy.tf
@@ -1,7 +1,6 @@
-moved {
-  from = azapi_resource.rai_policy
-  to   = module.rai_policy.azapi_resource.this
-}
+# NOTE: no `moved` block migrating `azapi_resource.rai_policy` into `module.rai_policy`,
+# for the same reason as `module.deployment` in main.tf - a `for_each`'d resource cannot be
+# moved into a `for_each`'d module call. See the migration guide in the README.
 
 module "rai_policy" {
   source   = "./modules/rai_policy"

--- a/main.tf
+++ b/main.tf
@@ -225,15 +225,22 @@ resource "azurerm_cognitive_account_customer_managed_key" "this" {
   }
 }
 
-moved {
-  from = azurerm_cognitive_deployment.this
-  to   = azapi_resource.cognitive_deployment
-}
-
-moved {
-  from = azapi_resource.cognitive_deployment
-  to   = module.deployment.azapi_resource.this
-}
+# NOTE: there is deliberately no `moved` block migrating `azapi_resource.cognitive_deployment`
+# into `module.deployment`.
+#
+# Terraform cannot express a move from a `for_each`'d resource into a `for_each`'d module
+# call. The source instance keys are applied to the *last* component of the target address,
+# producing `module.deployment.azapi_resource.this["<key>"]` instead of
+# `module.deployment["<key>"].azapi_resource.this`. That address does not exist in the
+# configuration, so Terraform reports `module.deployment is not in configuration`, plans a
+# destroy, and then creates the deployment fresh - dropping the live model endpoint.
+#
+# Cardinality must stay on the module call (AVM TFRMNFR1 forbids `for_each` on a submodule's
+# primary resource), so this migration cannot be shipped by the module. Consumers upgrading
+# from v0.11.1 or earlier declare per-key `moved` blocks in their own configuration instead;
+# see "Migration Guide for Cognitive Deployments and RAI Policies" in the README.
+#
+# Ref: https://github.com/Azure/terraform-azurerm-avm-res-cognitiveservices-account/issues/202
 
 module "deployment" {
   source   = "./modules/deployment"


### PR DESCRIPTION
## Description

Closes #202

`v0.11.1` relocated model deployments and RAI policies from root-level resources into the `modules/deployment` and `modules/rai_policy` submodules, and shipped `moved` blocks pointing at `module.deployment.azapi_resource.this` / `module.rai_policy.azapi_resource.this`.

Both module calls are `for_each`'d, so those targets address a **singleton** `module.deployment` that is not in the configuration. Terraform applies the source resource's instance keys to the *last* component of the target address, so the move resolves to the wrong thing:

```text
module.deployment.azapi_resource.this["<key>"]     # what the moved block produces
module.deployment["<key>"].azapi_resource.this     # what the configuration actually declares
```

Terraform reports `module.deployment is not in configuration`, plans a destroy, and then creates the deployment fresh. Destroying a live `Microsoft.CognitiveServices/accounts/deployments` drops the model endpoint during apply and risks capacity/quota reclaim failures on recreate.

### Why this can't be fixed inside the module

A single `moved` block cannot express a resource-`for_each` to module-`for_each` migration — the source's *resource* instance keys cannot become *module* instance keys.

The obvious alternative, making the submodule a singleton with `for_each` on `azapi_resource.this` inside it, is not available either: [TFRMNFR1](https://azure.github.io/Azure-Verified-Modules/spec/TFRMNFR1) states that a submodule's primary `azapi_resource` **MUST NOT** declare `count` or `for_each`, and that cardinality is the parent module's responsibility. Reverting deployments to a root-level resource conflicts with the same spec, which requires subresources to be implemented as submodules.

So the migration has to be declared by the consumer. This PR removes the blocks that silently destroy, and documents the per-key `moved` blocks that actually work.

### Changes

- Remove the unresolvable `moved` blocks in `main.tf` and `main.rai_policy.tf`, with comments at both sites explaining why one cannot exist there, so they don't get re-added.
- Also remove `moved { from = azurerm_cognitive_deployment.this, to = azapi_resource.cognitive_deployment }`. Its target stopped existing in v0.11.1, so it now just relocates state onto another orphan address. **Flagging this one for maintainer review:** the migration guide instead tells pre-`azapi` users to move straight to the new address in one hop, relying on the provider cross-type move this module already uses for `azurerm_cognitive_account.this[0]` -> `azapi_resource.this[0]`. Happy to restore it if you would rather keep a two-step path.
- Add a "Migration Guide for Cognitive Deployments and RAI Policies" section to `_header.md` and `README.md`, including a snippet that generates the required `moved` blocks from `terraform state list`.

### Scope note

The identical defect exists for RAI policies in `main.rai_policy.tf`, which #202 does not mention: `azapi_resource.rai_policy` -> `module.rai_policy.azapi_resource.this` fails the same way. Fixed here too, since shipping one fix and leaving the other landmine in the same release would still destroy resources on upgrade. Happy to split it into a separate PR if you prefer.

### Testing

I do not have an Azure subscription to run the module's e2e tests against, so this has **not** been validated with a real `terraform plan` / `apply`. What I did verify:

- All `.tf` files in the repo parse cleanly.
- Every remaining `moved` block in the repo targets an address that still exists in the configuration.
- The generator snippet was extracted back out of the rendered `README.md`, with blockquote markers stripped, and run against representative `terraform state list` output — it emits correct `moved` blocks verbatim as published.

A maintainer with a test subscription should confirm the upgrade path against a real v0.11.0 state file before release.

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

> On the last two boxes: I could not run the AVM pre-commit tooling or the module pipelines in my environment (no Terraform binary, no test subscription), so I have left them unchecked rather than tick them untruthfully. Relying on CI here — happy to push fixups for anything it flags, including `terraform fmt` and `terraform-docs` regeneration.
